### PR TITLE
Bump nuget with vulnerable transient dependency

### DIFF
--- a/src/IdentityModel.AspNetCore.ScopeValidation/IdentityModel.AspNetCore.ScopeValidation.csproj
+++ b/src/IdentityModel.AspNetCore.ScopeValidation/IdentityModel.AspNetCore.ScopeValidation.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="1.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="1.1.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="1.1.1" />
   </ItemGroup>
 


### PR DESCRIPTION
Re: https://github.com/dotnet/corefx/issues/19535

The vulnerable `System.Text.Encodings.Web/4.3.0` is referred via `Microsoft.AspNetCore.Http.Abstractions/1.1.1`. Bumping it to 1.1.2 fixes it.